### PR TITLE
Improve scanner logs and settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,6 +172,10 @@
                                         <input type="number" class="form-control" id="minLiquidity" value="50000" min="10000" max="500000">
                                     </div>
                                     <div class="form-group">
+                                        <label class="form-label">Min Volume/MC Ratio</label>
+                                        <input type="number" step="0.1" class="form-control" id="volumeMcapRatio" value="0.5" min="0" max="2">
+                                    </div>
+                                    <div class="form-group">
                                         <label class="form-label">Check Interval (ms)</label>
                                         <input type="number" class="form-control" id="checkInterval" value="5000" min="1000" max="60000">
                                     </div>

--- a/style.css
+++ b/style.css
@@ -839,6 +839,19 @@ select.form-control {
   align-items: center;
 }
 
+.alert-item.info {
+  color: var(--color-info);
+}
+.alert-item.success {
+  color: var(--color-success);
+}
+.alert-item.error {
+  color: var(--color-error);
+}
+.alert-item.warning {
+  color: var(--color-warning);
+}
+
 .position-item:last-child,
 .alert-item:last-child {
   border-bottom: none;


### PR DESCRIPTION
## Summary
- add volume/mcap ratio setting
- log API activity and use retrying fetch helper
- cache API results to avoid rate limit
- show logs in recent alerts list with colored styles
- update UI for new setting

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6872a1f240d883208065e638b8ad7e36