### PR TITLE
Fix BirdEye endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ class CryptoTradingSystem {
             dexscreener: "https://api.dexscreener.com/latest/",
             coingecko: "https://api.coingecko.com/api/v3/",
             jupiter: "https://lite-api.jup.ag/",
-            birdeye: "https://public-api.birdeye.so/defi/v3/",
+            birdeye: "https://public-api.birdeye.so/defi/",
             openai: "https://api.openai.com/v1/"
         };
         


### PR DESCRIPTION
## Summary
- revert Birdeye API base url to `/defi/`

## Testing
- `node -e "require('./app.js'); console.log('ok')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6872b2be57208320b92ac5dbe7817e7e