### PR TITLE
Improve crypto scanner functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,6 +251,7 @@
                         <div class="flex gap-8 mb-8">
                             <button class="btn btn--primary" onclick="startScanning()">Start Scanner</button>
                             <button class="btn btn--secondary" onclick="stopScanning()">Stop Scanner</button>
+                            <button class="btn btn--outline" onclick="testDataSources()">Test Data Sources</button>
                             <span class="scanner-status" id="scannerStatus">Oprit</span>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- broaden DexScreener scan and add detailed logging
- scan Helius for recent token mints instead of a fixed address
- relax token filters and log rejection reasons
- add verbose logging for market scans
- provide a `testDataSources` utility and button in UI

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6872b53e443483208fb3922d7937c938