### PR TITLE
Add Pump.Fun scanning

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,17 @@
                                 <button class="btn btn--primary" onclick="testApiConnection('openai')">Test Conexiune LLM</button>
                             </div>
                         </div>
+
+                        <div class="card">
+                            <div class="card__header">
+                                <h3>PumpPortal WS</h3>
+                                <span class="api-status" id="pumpfunStatus">Deconectat</span>
+                            </div>
+                            <div class="card__body">
+                                <p class="text-secondary">Nu necesită API Key</p>
+                                <button class="btn btn--primary" onclick="testApiConnection('pumpfun')">Test Conexiune</button>
+                            </div>
+                        </div>
                     </div>
                     
                     <div class="mt-8">


### PR DESCRIPTION
## Summary
- integrate Pump.Fun endpoint and PumpPortal websocket
- scan Pump.Fun via Helius and merge with DexScreener and Birdeye results
- add PumpPortal connection test and UI card

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6872bb95905c83209e6aac84c61034a7