### PR TITLE
Fix pump fun connection check

### DIFF
--- a/app.js
+++ b/app.js
@@ -149,7 +149,8 @@ class CryptoTradingSystem {
     
     async testApiConnection(apiName) {
         const key = this.apiKeys[apiName];
-        if (!key && apiName !== 'dexscreener') {
+        const noKeyRequired = ['dexscreener', 'pumpfun'];
+        if (!key && !noKeyRequired.includes(apiName)) {
             this.showToast(`API Key pentru ${apiName} nu este configurat`, 'error');
             return;
         }


### PR DESCRIPTION
## Summary
- allow pump fun connection check without requiring an API key

## Testing
- `node -c app.js`
- `node -e "require('./app.js')" > /dev/null` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6877aea6c2088320912a7961c7f0cea6